### PR TITLE
Fixed chrome select drop down flickering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>de.uniwue</groupId>
     <artifactId>OCR4all_Web</artifactId>
     <packaging>war</packaging>
-    <version>0.1.1</version>
+    <version>0.1.1-1</version>
     <name>OCR4all_Web Maven Webapp</name>
     <url>http://maven.apache.org</url>
 

--- a/src/main/webapp/WEB-INF/tags/head.tag
+++ b/src/main/webapp/WEB-INF/tags/head.tag
@@ -24,6 +24,14 @@
     <link type="text/css" rel="stylesheet" href="${pageContext.servletContext.contextPath}/resources/css/ocr4allweb.css">
     <script type="text/javascript" src="${pageContext.servletContext.contextPath}/resources/js/ocr4allweb-helper.js"></script>
 
+    <!-- Hot fix patches -->
+    <script type="text/javascript">
+        /* Fix Chrome select drop down close on first click.
+         * Needed for materialize css v0.100.2 (fixed in v1.0.0 and higher)
+         * https://github.com/InfomediaLtd/angular2-materialize/issues/444#issuecomment-497063955
+         */
+        $(document).on("click",".select-wrapper",(e) => e.stopPropagation()); 
+    </script>
     <c:choose>
         <%-- Include JS files to provide image list functionality --%>
         <c:when test="${not empty imageList}">


### PR DESCRIPTION
Fixed chrome flickering on select drop down
============================
The first click on a select opened and immediately closed its drop down menu.
Fixed it via [stopPropagation on select wrapper](https://github.com/InfomediaLtd/angular2-materialize/issues/444#issuecomment-497063955).

This problem is only present in materialize css before 1.0.0, caused by a change in the chrome browser.
Updating is currently not feasible (See [update_materialize branch](https://github.com/OCR4all/OCR4all/tree/update_materialize) ).