### PR TITLE
Fixed OpenCV specific memory leaks

### DIFF
--- a/src/main/java/de/uniwue/feature/ImageResize.java
+++ b/src/main/java/de/uniwue/feature/ImageResize.java
@@ -37,7 +37,7 @@ public class ImageResize {
      * @return Mat representation of the scaled image file
      * @throws IOException 
      */
-    public Mat getScaledImage(Mat img) throws IOException {
+    public Mat getScaledImage(final Mat img) throws IOException {
         Dimension dimension = getDimension(img);
         if (dimension != null) {
             Imgproc.resize(img, img, new Size(dimension.width, dimension.height) );
@@ -52,7 +52,7 @@ public class ImageResize {
      * @param img The image to be scaled
      * @return Calculated dimension
      */
-    private Dimension getDimension(Mat img) {
+    private Dimension getDimension(final Mat img) {
         Dimension dimension = null;
         if (resizeHeight != -1 || resizeWidth != -1) {
             if (resizeHeight != -1 && resizeWidth != -1) {

--- a/src/main/java/de/uniwue/feature/ProcessHandler.java
+++ b/src/main/java/de/uniwue/feature/ProcessHandler.java
@@ -41,9 +41,8 @@ public class ProcessHandler {
 
         @Override
         public void run() {
-            try {
-            BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
-            String nextLine = null;
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))){
+                String nextLine = null;
                 while ((nextLine = reader.readLine()) != null) {
                     consumeInputLine.accept(nextLine);
                 }

--- a/src/main/java/de/uniwue/feature/ProcessStateCollector.java
+++ b/src/main/java/de/uniwue/feature/ProcessStateCollector.java
@@ -145,8 +145,7 @@ public class ProcessStateCollector {
 
         // Easy and fast check if an end tag of a TextLine exists 
         // Does not check if the xml is valid
-        try {
-			FileInputStream fis = new FileInputStream(pageXML);
+        try (FileInputStream fis = new FileInputStream(pageXML)) {
 			byte[] data = new byte[(int) pageXML.length()];
 			fis.read(data);
 			fis.close();
@@ -232,8 +231,7 @@ public class ProcessStateCollector {
 
 			// Easy and fast check if an end tag of a TextLine exists 
 			// Does not check if the xml is valid
-			try {
-				FileInputStream fis = new FileInputStream(pageXML);
+			try (FileInputStream fis = new FileInputStream(pageXML)){
 				byte[] data = new byte[(int) pageXML.length()];
 				fis.read(data);
 				fis.close();
@@ -280,8 +278,7 @@ public class ProcessStateCollector {
 
 			// Easy and fast check if an end tag of a TextLine exists 
 			// Does not check if the xml is valid
-			try {
-				FileInputStream fis = new FileInputStream(pageXML);
+			try (FileInputStream fis = new FileInputStream(pageXML)){
 				byte[] data = new byte[(int) pageXML.length()];
 				fis.read(data);
 				fis.close();

--- a/src/main/java/de/uniwue/feature/RegionExtractor.java
+++ b/src/main/java/de/uniwue/feature/RegionExtractor.java
@@ -50,7 +50,7 @@ public class RegionExtractor {
         List<String> regions = new ArrayList<String>();
         Page page = PageXMLImport.readPageXML(xmlPath);
         //maybe use flags if regions are extracted from binary/grayscale (which should be the case)
-        Mat image = Imgcodecs.imread(imagePath);
+        final Mat image = Imgcodecs.imread(imagePath);
 
         //maybe some checks needed. image.width == 0 etc.
         String pageIdentifier = page.getImageFilename().substring(0,
@@ -99,21 +99,25 @@ public class RegionExtractor {
      * @param outputPath Path, where the file should be stored
      * @throws IOException
      */
-    public static boolean saveImage(ArrayList<Point> pointList, Mat image,
+    public static boolean saveImage(ArrayList<Point> pointList, final Mat image,
             int spacing,
             String outputPath) throws IOException {
         Scalar avgBgd = new Scalar(255, 255, 255);
 
-        MatOfPoint points = new MatOfPoint(
+        final MatOfPoint points = new MatOfPoint(
                 pointList.toArray(new Point[pointList.size()]));
         Rect rect = Imgproc.boundingRect(points);
 
-        Mat mask = new Mat(image.size(), CvType.CV_8UC1, new Scalar(0));
-        Mat bgd = new Mat(image.size(), image.type(), avgBgd);
+        final Mat mask = new Mat(image.size(), CvType.CV_8UC1, new Scalar(0));
+        final Mat bgd = new Mat(image.size(), image.type(), avgBgd);
 
-        ArrayList<MatOfPoint> contours = new ArrayList<MatOfPoint>();
+        final ArrayList<MatOfPoint> contours = new ArrayList<MatOfPoint>();
         contours.add(points);
         Imgproc.drawContours(mask, contours, -1, new Scalar(255), -1);
+
+        for(final MatOfPoint contour : contours){
+            contour.release();
+        }
 
         image.copyTo(bgd, mask);
 
@@ -143,9 +147,9 @@ public class RegionExtractor {
                 result = new Mat(bgd, newRect);
             } else {
                 result = new Mat(newRect.size(), bgd.type(), avgBgd);
-                Mat submat = result.submat(new Rect(spacing, spacing,
+                final Mat submat = result.submat(new Rect(spacing, spacing,
                         rect.width, rect.height));
-                Mat tempResult = new Mat(bgd, rect);
+                final Mat tempResult = new Mat(bgd, rect);
                 tempResult.copyTo(submat);
 
                 releaseAll(submat, tempResult);
@@ -163,11 +167,10 @@ public class RegionExtractor {
      * Frees memory of the mat object which was allocated by the imread method
      * @param mats objects which should get released
      */
-    public static void releaseAll(Mat... mats) {
-        for(Mat mat : mats) {
+    public static void releaseAll(final Mat... mats) {
+        for(final Mat mat : mats) {
             if (mat != null) {
                 mat.release();
-                mat = null;
             }
         }
     }
@@ -177,14 +180,14 @@ public class RegionExtractor {
      * @param original Mat object of the image
      * @return average background color
      */
-    public static double[] calcAverageBackground(Mat original) {
+    public static double[] calcAverageBackground(final Mat original) {
         if (original.channels() == 1) {
             return calcAverageBackgroundGray(original);
         }
         
-        Mat gray = new Mat();
+        final Mat gray = new Mat();
         Imgproc.cvtColor(original, gray, Imgproc.COLOR_BGR2GRAY);
-        Mat binary = new Mat();
+        final Mat binary = new Mat();
         Imgproc.threshold(gray, binary, -1, 255, Imgproc.THRESH_OTSU);
 
         double sumRed = 0;
@@ -215,8 +218,8 @@ public class RegionExtractor {
      * @param gray Mat object of the grayscale image
      * @return average background color
      */
-    public static double[] calcAverageBackgroundGray(Mat gray) {
-        Mat binary = new Mat();
+    public static double[] calcAverageBackgroundGray(final Mat gray) {
+        final Mat binary = new Mat();
         Imgproc.threshold(gray, binary, -1, 255, Imgproc.THRESH_OTSU);
 
         double sum = 0;

--- a/src/main/java/de/uniwue/feature/pageXML/PageXMLWriter.java
+++ b/src/main/java/de/uniwue/feature/pageXML/PageXMLWriter.java
@@ -67,7 +67,7 @@ public class PageXMLWriter {
      * @return pageXML document or null if parse error
      * @throws ParserConfigurationException 
      */
-    public static Document getPageXML(Mat image, String imageFilename, String pageXMLVersion) throws ParserConfigurationException {
+    public static Document getPageXML(final Mat image, String imageFilename, String pageXMLVersion) throws ParserConfigurationException {
         if (!pageXMLVersion.equals("2017-07-15") && !pageXMLVersion.equals("2010-03-19")) {
             pageXMLVersion = "2010-03-19";
         }

--- a/src/main/java/de/uniwue/helper/DespecklingHelper.java
+++ b/src/main/java/de/uniwue/helper/DespecklingHelper.java
@@ -72,11 +72,13 @@ public class DespecklingHelper {
             if (stop == true) 
                 break;
 
-            Mat mat = Imgcodecs.imread(projConf.BINR_IMG_DIR + File.separator + pageId + projConf.BINR_IMG_EXT);
+            final Mat mat = Imgcodecs.imread(projConf.BINR_IMG_DIR + File.separator + pageId + projConf.BINR_IMG_EXT);
             // Only the "standard" parameter is needed when despeckling
             // "marked" is only used to highlight changes for the user
-            mat = ImageDespeckle.despeckle(mat, maxContourRemovalSize, "standard");
-            Imgcodecs.imwrite(projConf.DESP_IMG_DIR + File.separator + pageId + projConf.DESP_IMG_EXT, mat);
+            final Mat despeckled = ImageDespeckle.despeckle(mat, maxContourRemovalSize, "standard");
+            mat.release();
+            Imgcodecs.imwrite(projConf.DESP_IMG_DIR + File.separator + pageId + projConf.DESP_IMG_EXT, despeckled);
+            despeckled.release();
 
             progress = (int) (i / totalPages * 100);
             i = i + 1;

--- a/src/main/java/de/uniwue/helper/ImageHelper.java
+++ b/src/main/java/de/uniwue/helper/ImageHelper.java
@@ -49,10 +49,12 @@ public class ImageHelper {
      * @param img Mat of the image
      * @return Byte array of the image
      */
-    private byte[] convertImageMatToByte(Mat img) {
-        MatOfByte matOfByte = new MatOfByte();
+    private byte[] convertImageMatToByte(final Mat img) {
+        final MatOfByte matOfByte = new MatOfByte();
         Imgcodecs.imencode(projConf.IMG_EXT, img, matOfByte); 
-        return matOfByte.toArray();
+        final byte[] bytes = matOfByte.toArray();
+        matOfByte.release();
+        return bytes;
     }
 
     /**
@@ -62,12 +64,12 @@ public class ImageHelper {
      * @return Returns the image as a base64 string
      * @throws IOException
      */
-    private String getImageAsBase64(Mat img) throws IOException {
-        if (imageResize != null) {
-            img = imageResize.getScaledImage(img);
-        }
+    private String getImageAsBase64(final Mat img) throws IOException {
+    	Mat workImage = (imageResize != null) ? imageResize.getScaledImage(img) : img;
 
-        byte[] returnBuff = convertImageMatToByte(img);
+        byte[] returnBuff = convertImageMatToByte(workImage);
+        if(imageResize != null)
+        	workImage.release();
         if (returnBuff == null)
             return "";
 
@@ -82,11 +84,13 @@ public class ImageHelper {
      * @throws IOException
      */
     private String getImageAsBase64(String path) throws IOException {
-        Mat img = Imgcodecs.imread(path);
+        final Mat img = Imgcodecs.imread(path);
         if (img.empty())
             return "";
 
-        return getImageAsBase64(img);
+        String base64 = getImageAsBase64(img);
+        img.release();
+        return base64;
     }
 
     /**
@@ -140,8 +144,12 @@ public class ImageHelper {
      * @throws IOException 
      */
     public String getPreviewDespeckleAsBase64(String pageId, double maxContourRemovalSize, String illustrationType) throws IOException {
-        Mat binImage = Imgcodecs.imread(projConf.BINR_IMG_DIR + File.separator + pageId + projConf.BINR_IMG_EXT);
-        Mat despImage = ImageDespeckle.despeckle(binImage, maxContourRemovalSize, illustrationType);
-        return getImageAsBase64(despImage);
+        final Mat binImage = Imgcodecs.imread(projConf.BINR_IMG_DIR + File.separator + pageId + projConf.BINR_IMG_EXT);
+        final Mat despImage = ImageDespeckle.despeckle(binImage, maxContourRemovalSize, illustrationType);
+        binImage.release();
+        String base64 = getImageAsBase64(despImage);
+        despImage.release();
+
+        return base64;
     }
 }

--- a/src/main/java/de/uniwue/helper/OverviewHelper.java
+++ b/src/main/java/de/uniwue/helper/OverviewHelper.java
@@ -393,7 +393,7 @@ public class OverviewHelper {
                 if (stopProcess == true)
                     return;
 
-                Mat image = Imgcodecs.imread(fileEntry.getAbsolutePath());
+                final Mat image = Imgcodecs.imread(fileEntry.getAbsolutePath());
                 // Convert and save as new image file
                 Imgcodecs.imwrite(FilenameUtils.removeExtension(fileEntry.getAbsolutePath()) + projConf.IMG_EXT, image);
                 // Remove old image file (project needs to be valid for the loading process)
@@ -659,7 +659,7 @@ public class OverviewHelper {
      * @param whiteFactor Percent brightness a pixel has to have to be considered bland [0,1]
      * @return TRUE if Page is blank
      */
-    private boolean isBlank(Mat img, double areaFactor, double whiteFactor) {
+    private boolean isBlank(final Mat img, double areaFactor, double whiteFactor) {
         if (!(0 <= areaFactor && areaFactor <= 1) || !(0 <= whiteFactor && whiteFactor <= 1)) {
             throw new IllegalArgumentException("Percent factors are not in range of 0% and 100%");
         }
@@ -693,11 +693,14 @@ public class OverviewHelper {
      * @param image buffered image
      * @return matrix of the buffered image
      */
-    public Mat bufferedImageToMat(BufferedImage image) throws IOException {
+    public Mat bufferedImageToMat(BufferedImage bufferedimage) throws IOException {
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        ImageIO.write(image, "png", byteArrayOutputStream);
+        ImageIO.write(bufferedimage, "png", byteArrayOutputStream);
         byteArrayOutputStream.flush();
-        return Imgcodecs.imdecode(new MatOfByte(byteArrayOutputStream.toByteArray()), Imgcodecs.CV_LOAD_IMAGE_UNCHANGED);
+        final MatOfByte bytes = new MatOfByte(byteArrayOutputStream.toByteArray());
+        final Mat image = Imgcodecs.imdecode(bytes, Imgcodecs.CV_LOAD_IMAGE_UNCHANGED);
+        bytes.release();
+        return image;
     }
 
 }

--- a/src/main/java/de/uniwue/helper/SegmentationDummyHelper.java
+++ b/src/main/java/de/uniwue/helper/SegmentationDummyHelper.java
@@ -106,7 +106,7 @@ public class SegmentationDummyHelper {
         String imagePath = file.getAbsolutePath();
         String imageFilename = imagePath.substring(imagePath.lastIndexOf(File.separator) + 1).
         								 replace(projConf.getImageExtensionByType(projectImageType), projConf.IMG_EXT);
-        Mat image = Imgcodecs.imread(imagePath);
+        final Mat image = Imgcodecs.imread(imagePath);
         if(image.width() == 0)
             return;
         Document xml = PageXMLWriter.getPageXML(image, imageFilename, "2017-07-15");

--- a/src/main/java/de/uniwue/model/TextRegion.java
+++ b/src/main/java/de/uniwue/model/TextRegion.java
@@ -51,8 +51,9 @@ public class TextRegion implements Comparable<TextRegion> {
         Point[] pointArray = new Point[points.size()];
         pointArray = points.toArray(pointArray);
         
-        MatOfPoint pointMat = new MatOfPoint(pointArray);
+        final MatOfPoint pointMat = new MatOfPoint(pointArray);
         Rect rect = Imgproc.boundingRect(pointMat);
+        pointMat.release();
 
         this.rect = rect;
     }


### PR DESCRIPTION
Fixed a few potential memory leaks with OpenCV Mats/MatOfPoint/MatOfByte.
Made all those references final (to combat "loosing" the object before releasing it) and released them after they are no longer needed.