### PR TITLE
Add pagexml fixes and warning for legacy project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>de.uniwue</groupId>
     <artifactId>OCR4all_Web</artifactId>
     <packaging>war</packaging>
-    <version>0.1.1-3</version>
+    <version>0.1.1-4</version>
     <name>OCR4all_Web Maven Webapp</name>
     <url>http://maven.apache.org</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>de.uniwue</groupId>
     <artifactId>OCR4all_Web</artifactId>
     <packaging>war</packaging>
-    <version>0.1.1-4</version>
+    <version>0.1.1-4.1</version>
     <name>OCR4all_Web Maven Webapp</name>
     <url>http://maven.apache.org</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>de.uniwue</groupId>
     <artifactId>OCR4all_Web</artifactId>
     <packaging>war</packaging>
-    <version>0.1.1-2</version>
+    <version>0.1.1-3</version>
     <name>OCR4all_Web Maven Webapp</name>
     <url>http://maven.apache.org</url>
 

--- a/src/main/java/de/uniwue/controller/DespecklingController.java
+++ b/src/main/java/de/uniwue/controller/DespecklingController.java
@@ -110,6 +110,9 @@ public class DespecklingController {
             return;
 
         despecklingHelper.cancelDespecklingProcess();
+        // Directly remove despeckling from process list and
+        // let it cancel in the background
+        GenericController.removeFromProcessList(session, "despeckling");
     }
 
     /**

--- a/src/main/java/de/uniwue/controller/GenericController.java
+++ b/src/main/java/de/uniwue/controller/GenericController.java
@@ -52,7 +52,8 @@ import de.uniwue.helper.GenericHelper;
         if (processList == null)
             processList = new ArrayList<String>();
 
-        processList.add(process);
+        if(!processList.contains(process)) 
+			processList.add(process);
         session.setAttribute("processList", processList);
     }
 

--- a/src/main/java/de/uniwue/controller/OverviewController.java
+++ b/src/main/java/de/uniwue/controller/OverviewController.java
@@ -221,6 +221,22 @@ public class OverviewController {
     }
 
     /**
+     * Response to the request to check if this project includes legacy (Directory) files
+     *
+     * @param session Session of the user
+     * @param response Response to the request
+     * @return Returns the status of the filename check
+     */
+    @RequestMapping(value ="/ajax/overview/isLegacy" , method = RequestMethod.GET)
+    public @ResponseBody boolean checkLegacy(HttpSession session, HttpServletResponse response) {
+        OverviewHelper overviewHelper = provideHelper(session, response);
+        if (overviewHelper == null)
+            return false;
+
+	   return overviewHelper.isLegacy();
+    }
+
+    /**
      * Response to adjust the files according to the project standard
      *
      * @param backupImages Determines if a backup of the image folder is required 

--- a/src/main/java/de/uniwue/feature/RegionExtractor.java
+++ b/src/main/java/de/uniwue/feature/RegionExtractor.java
@@ -64,7 +64,6 @@ public class RegionExtractor {
 
             String index = page.getReadingOrder().findIndex(region.getId());
 
-            //the PageXML representation of the reading order is retarded
             if (index != null) {
                 String id = index.replace("r", "");
 

--- a/src/main/java/de/uniwue/feature/pageXML/PageXMLImport.java
+++ b/src/main/java/de/uniwue/feature/pageXML/PageXMLImport.java
@@ -144,6 +144,26 @@ public class PageXMLImport {
     }
 
     /**
+     * Creates an Arraylist of RegionRefIndexed objects from an xml element
+     * The RegionRefindex represents the reading order of the different textregions
+     * @param orderedGroup extracted XML node
+     * @return Arraylist of RegionRefIndexed
+     */
+    private static ArrayList<RegionRefIndexed> extractRegionRef(Element unorderedGroup) {
+        ArrayList<RegionRefIndexed> regionRefIndices = new ArrayList<RegionRefIndexed>();
+        NodeList rriNodes = unorderedGroup.getElementsByTagName("RegionRef");
+
+        for (int i = 0; i < rriNodes.getLength(); i++) {
+            Element rriElement = (Element) rriNodes.item(i);
+            String regionRef = rriElement.getAttribute("regionRef");
+
+            RegionRefIndexed rri = new RegionRefIndexed(""+i, regionRef);
+            regionRefIndices.add(rri);
+        }
+
+        return regionRefIndices;
+    }
+    /**
      * Creates a readingOrder object from the extracted xml element
      * @param readingOrderElement extracted XML element
      * @return ReadingOrder object, which represents the readingOrder of the page
@@ -152,11 +172,16 @@ public class PageXMLImport {
         if (readingOrderElement == null) {
             return null;
         }
+		ArrayList<RegionRefIndexed> regionRefIndices;
+        Element readingOrderList = (Element) readingOrderElement.getElementsByTagName("OrderedGroup").item(0);
+        if(readingOrderList != null) {
+			regionRefIndices = extractRegionRefIndices(readingOrderList);
+        } else {
+			readingOrderList = (Element) readingOrderElement.getElementsByTagName("UnorderedGroup").item(0);
+			regionRefIndices = extractRegionRef(readingOrderList);
+        }
 
-        Element orderedGroup = (Element) readingOrderElement.getElementsByTagName("OrderedGroup").item(0);
-        String id = orderedGroup.getAttribute("id");
-
-        ArrayList<RegionRefIndexed> regionRefIndices = extractRegionRefIndices(orderedGroup);
+        String id = readingOrderList.getAttribute("id");
         ReadingOrder readingOrder = new ReadingOrder(id, regionRefIndices);
 
         return readingOrder;

--- a/src/main/java/de/uniwue/helper/DespecklingHelper.java
+++ b/src/main/java/de/uniwue/helper/DespecklingHelper.java
@@ -77,11 +77,14 @@ public class DespecklingHelper {
             // "marked" is only used to highlight changes for the user
             final Mat despeckled = ImageDespeckle.despeckle(mat, maxContourRemovalSize, "standard");
             mat.release();
-            Imgcodecs.imwrite(projConf.DESP_IMG_DIR + File.separator + pageId + projConf.DESP_IMG_EXT, despeckled);
+            // Save if process is not stopped 
+            // (despeckling can take a while, since the last stop test)
+            if(stop != false) {
+				Imgcodecs.imwrite(projConf.DESP_IMG_DIR + File.separator + pageId + projConf.DESP_IMG_EXT, despeckled);
+				progress = (int) (i / totalPages * 100);
+				i = i + 1;
+            }
             despeckled.release();
-
-            progress = (int) (i / totalPages * 100);
-            i = i + 1;
         }
 
         progress = 100;

--- a/src/main/java/de/uniwue/helper/OverviewHelper.java
+++ b/src/main/java/de/uniwue/helper/OverviewHelper.java
@@ -351,6 +351,24 @@ public class OverviewHelper {
     }
 
     /**
+     * Checks if the project structure of this project is a legacy project (Directory)
+     *
+     * @return Project validation status
+     * @throws IOException 
+     */
+    public boolean isLegacy() {
+		File project = Paths.get(projConf.OCR_DIR).toFile();
+		// Check for every folder inside the inputs folder that consists of 
+		// numbers and may therefore be legacy data
+		long numberDirectories = Arrays.stream(project.listFiles())
+				.filter(f -> f.isDirectory())
+				.filter(f -> f.getName().matches("\\d{4}"))
+				.count();
+		
+		return numberDirectories > 0;
+    }
+
+    /**
      * Lists all available projects from the data directory
      *
      * @return Map of projects (key = projName | value = path)

--- a/src/main/webapp/WEB-INF/tags/settings/overview.tag
+++ b/src/main/webapp/WEB-INF/tags/settings/overview.tag
@@ -64,8 +64,8 @@
                         <c:otherwise><c:set value='selected="selected"' var="pagexmlSel"></c:set></c:otherwise>
                     </c:choose>
                     <select id="processingMode" name="processingMode" class="suffix">
-                        <option value="Pagexml" ${pagexmlSel}>PageXML</option>
-                        <option value="Directory" ${directorySel}>Directory</option>
+                        <option value="Pagexml" ${pagexmlSel}>Latest</option>
+                        <option value="Directory" ${directorySel}>Legacy</option>
                     </select>
                     <label></label>
                 </div>

--- a/src/main/webapp/WEB-INF/views/overview.jsp
+++ b/src/main/webapp/WEB-INF/views/overview.jsp
@@ -73,7 +73,7 @@
                 }
 
                 // Responsible for verification and loading of the project
-                function projectInitialization(newPageVisit) {
+                function projectInitialization(newPageVisit, allowLegacy=false) {
                     var ajaxParams = { "projectDir" : $('#projectDir').val(), "imageType" : $('#imageType').val(), "processingMode" : $('#processingMode').val() };
                     // Check if directory exists
                     $.get( "ajax/overview/checkDir?",
@@ -89,31 +89,42 @@
                                     $.get( "ajax/overview/validateProject?", ajaxParams )
                                     .done(function( data ) {
                                          if( data === true ) {
-
-                                             // Check if dir only houses pdf files and no images
-                                             $.get("ajax/overview/checkpdf")
-                                                 .done(function(data) {
-                                                 if( data === true) {
-                                                     openCollapsibleEntriesExclusively([0]);
-                                                     $('#modal_convertpdf').modal({
-                                                         dismissible: false
-                                                     });
-                                                     $('#modal_convertpdf').modal('open');
-                                                 }
-                                                 else {
-                                                     // Two scenarios for loading overview page:
-                                                     // 1. Load or reload new project: Page needs reload to update GTC_Web link in navigation
-                                                     // 2. Load project due to revisiting overview page: Only datatable needs to be initialized
-                                                     if( newPageVisit == false ) {
-                                                         location.reload();
-                                                     }
-                                                     else {
-                                                         // Load datatable after the last process update is surely finished
-                                                         datatable();
-                                                     }
-                                                 }
-                                             });
-
+                                            if( !allowLegacy && ($('#processingMode').val() === "Pagexml") ){
+                                                // Check if the project still contains legacy files
+                                                $.get("ajax/overview/isLegacy")
+                                                .done(function(data) {
+                                                    if( data === true ){
+                                                        $('#modal_legacy').modal({
+                                                            dismissible: true
+                                                        });
+                                                        $('#modal_legacy').modal('open');
+                                                    }
+                                                });
+                                            } else {
+                                                // Check if dir only houses pdf files and no images
+                                                $.get("ajax/overview/checkpdf")
+                                                    .done(function(data) {
+                                                    if( data === true) {
+                                                        openCollapsibleEntriesExclusively([0]);
+                                                        $('#modal_convertpdf').modal({
+                                                            dismissible: false
+                                                        });
+                                                        $('#modal_convertpdf').modal('open');
+                                                    }
+                                                    else {
+                                                        // Two scenarios for loading overview page:
+                                                        // 1. Load or reload new project: Page needs reload to update GTC_Web link in navigation
+                                                        // 2. Load project due to revisiting overview page: Only datatable needs to be initialized
+                                                        if( newPageVisit == false ) {
+                                                            location.reload();
+                                                        }
+                                                        else {
+                                                            // Load datatable after the last process update is surely finished
+                                                            datatable();
+                                                        }
+                                                    }
+                                                });
+                                            }
                                          }
                                          else{
                                              openCollapsibleEntriesExclusively([0]);
@@ -196,7 +207,7 @@
                         }
                     }, 500);
                 });
-                $('#cancelConvertPdf').click(function() {
+                $('#cancelConvertPdf', '#cancelLegacy').click(function() {
                     setTimeout(function() {
                         // Unload project if user refuses the mandatory adjustments
                         if( !isProcessRunning() ) {
@@ -222,7 +233,25 @@
                         .fail(function( data ) {
                         });
                 });
-
+                $('#continueLegacy').click(function() {
+                    setTimeout(function() {
+                        // Unload project if user refuses the mandatory adjustments
+                        if( !isProcessRunning() ) {
+                            projectInitialization(true, true);
+                        }
+                    }, 500);
+                });
+                $('#openLegacy').click(function() {
+                    setTimeout(function() {
+                        // Unload project if user refuses the mandatory adjustments
+                        if( !isProcessRunning() ) {
+                            const $processingMode = $("#processingMode");
+                            $processingMode.val("Directory");
+                            $processingMode.material_select();
+                            projectInitialization(false, false);
+                        }
+                    }, 500);
+                });
                 $('button[data-id="cancelProjectAdjustment"]').click(function() {
                     cancelProcess();
 
@@ -290,6 +319,9 @@
                     <li>
                         <div class="collapsible-header"><i class="material-icons">dehaze</i>Overview</div>
                         <div class="collapsible-body">
+                            <c:if test='${(not empty processingMode) && (processingMode == "Directory")}'>
+                            <p class="red-text">Loaded with Legacy (This mode will be removed in future OCR4all versions)</p>    
+                            </c:if>
                             <table id="overviewTable" class="display centered" width="100%"></table>
                         </div>
                     </li>
@@ -334,6 +366,22 @@
                 <a href="#!" id="backupAndConvert" class="modal-action modal-close waves-effect waves-green btn-flat">Backup and convert files</a>
             </div>
          </div>
+        <div id="modal_legacy" class="modal">
+            <div class="modal-content">
+                <h4 class="red-text">Warning: Legacy files found</h4>
+                <p>The project you are about to load with the "Latest" mode, includes files of an old version of OCR4all.</p>
+                <p>Please use the "Legacy" option under "Project processing mode" for those projects, 
+                    since some processing results from your project may otherwise not be available.</p>
+                <p>Opening and editing your project with the "Latest" processing mode will not delete any legacy data from your project,
+                    but existing legacy data from "Line Segmentations", "Recognitions" and "Ground Truth Productions" will not be accessible in this mode.</p>
+                <p>Be aware that the "Legacy" option will be removed in future OCR4all releases.</p>
+            </div>
+            <div class="modal-footer">
+                <a href="#!" id="continueLegacy" class="modal-action modal-close waves-effect waves-green btn-flat">Continue with Latest</a>
+                <a href="#!" id="openLegacy" class="modal-action modal-close waves-effect waves-green btn-flat">Load with Legacy</a>
+                <a href="#!" id="cancelLegacy" class="modal-action modal-close waves-effect waves-green btn-flat">Cancel</a>
+            </div>
+        </div>
         <div id="modal_convertpdf" class="modal">
             <div class="modal-content">
                 <h4 class="red-text">Convert PDF files</h4>


### PR DESCRIPTION
* Changed "Directory" mode to "Legacy" and "PageXML" mode to "Latest"
    * Added warning in projects opened in "Legacy" about deprecation
    * Added warning for legacy projects opened with "Latest"
    * "Legacy" mode will be removed in future versions
* Page XML files with Reading Order including UnorderedGroups can now be loaded
* Noise removal can now be canceled instantly (may take some time cancel in background, but will not affect any data)