### PR TITLE
Added enhanced filters for larex display multiple images

### DIFF
--- a/src/main/webapp/WEB-INF/tags/settings/larex.tag
+++ b/src/main/webapp/WEB-INF/tags/settings/larex.tag
@@ -23,7 +23,7 @@
                     <input type="hidden" id="bookname" name="bookname" value="processing" />
                     <input type="hidden" id="websave" name="websave" value="false" />
                     <input type="hidden" id="localsave" name="localsave" value="bookpath" />
-                    <input type="hidden" id="imagefilter" name="imagefilter" value="bin" />
+                    <input type="hidden" id="imagefilter" name="imagefilter" value="bin nrm desp" />
 					<c:if test="${not empty modes}" >
                     <input type="hidden" id="modes" name="modes" value="${modes}" />
 					</c:if>

--- a/src/main/webapp/WEB-INF/views/larex.jsp
+++ b/src/main/webapp/WEB-INF/views/larex.jsp
@@ -27,8 +27,8 @@
                 $('#imageType').on('change', function() {
                     let imageSubExt = ""; 
                     switch($('#imageType').val()){
-                        case "Binary": imageSubExt = "bin"; break;
-                        case "Despeckled": imageSubExt = "desp"; break;
+                        case "Binary": imageSubExt = "bin nrm"; break;
+                        case "Despeckled": imageSubExt = "desp nrm"; break;
                         default: imageSubExt = "";
                     }
                     $('#imagefilter').val(imageSubExt);


### PR DESCRIPTION
Added nrm / grayscale images into the Larex filter, to display grayscale images next to bin/desp images in the new Larex v0.1.9(d)