### PR TITLE
changed PdfBox version and switched to use of temp files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,27 +101,27 @@
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
-            <version>2.0.15</version>
+            <version>2.0.19</version>
         </dependency>
 
         <!-- PDFBox-tools https://mvnrepository.com/artifact/org.apache.pdfbox/pdfbox-tools -->
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox-tools</artifactId>
-            <version>2.0.15</version>
+            <version>2.0.19</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>jbig2-imageio</artifactId>
-            <version>3.0.2</version>
+            <version>3.0.3</version>
         </dependency>
 
         <!-- Java Advanced Imaging (JAI) Image I/O Tools -->
         <dependency>
             <groupId>com.github.jai-imageio</groupId>
             <artifactId>jai-imageio-core</artifactId>
-            <version>1.3.1</version>
+            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>com.github.jai-imageio</groupId>


### PR DESCRIPTION
PDFs are now split to single page PDFs and processed one at a time, decreasing Memory Load.
Usage of temp files adds the advantage of processing large amount of PDFs and processing very large PDFs at the cost of increasing processing time.
fixes #59 